### PR TITLE
Add wizard class as an argument to the onCompleteAction

### DIFF
--- a/src/AbstractWizard.php
+++ b/src/AbstractWizard.php
@@ -398,7 +398,7 @@ abstract class AbstractWizard
 
         $result = $this->actionResolver
             ->resolveAction($this->onCompleteAction)
-            ->execute($this->transformWizardData());
+            ->execute($this->transformWizardData(), $this);
 
         if (!$result->successful()) {
             return $this->responseRenderer->redirectWithError(

--- a/src/Action/WizardAction.php
+++ b/src/Action/WizardAction.php
@@ -4,7 +4,7 @@ namespace Arcanist\Action;
 
 abstract class WizardAction
 {
-    abstract public function execute($payload): ActionResult;
+    abstract public function execute($payload, $wizard): ActionResult;
 
     protected function success(array $payload = []): ActionResult
     {


### PR DESCRIPTION
The following PR will allow the `onCompleteAction` class to have information about the wizard in addition to the already available payload.

E.g.

```
<?php

namespace App\Wizards\Registration;

use Arcanist\Action\WizardAction;
use Arcanist\Action\ActionResult;

class RegistrationAction extends WizardAction
{
    public function execute($payload, $wizard): ActionResult
    {
        return $this->success();
    }
}
```