### PR TITLE
Change self to static in named Field constructor

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -14,9 +14,9 @@ class Field
     ) {
     }
 
-    public static function make(string $name): Field
+    public static function make(string $name): static
     {
-        return new self($name);
+        return new static($name);
     }
 
     public function rules(array $rules): self


### PR DESCRIPTION
As discussed [here](https://github.com/laravel-arcanist/arcanist/issues/9#issuecomment-880542402) I've prepared a small PR that allows instances of `Field`-subclasses to be created via the `make()` constructor.