### PR TITLE
Make function fields of a step public

### DIFF
--- a/src/Commands/stubs/step.stub
+++ b/src/Commands/stubs/step.stub
@@ -26,7 +26,7 @@ class DummyClass extends WizardStep
         return parent::viewData($request);
     }
 
-    protected function fields(): array
+    public function fields(): array
     {
         return [
             // Field::make('username')

--- a/src/WizardStep.php
+++ b/src/WizardStep.php
@@ -88,7 +88,7 @@ abstract class WizardStep
         return $this->success($payload);
     }
 
-    protected function fields(): array
+    public function fields(): array
     {
         return [];
     }

--- a/tests/InvalidateDependentFieldsTest.php
+++ b/tests/InvalidateDependentFieldsTest.php
@@ -176,7 +176,7 @@ class RegularStep extends WizardStep
         return true;
     }
 
-    protected function fields(): array
+    public function fields(): array
     {
         return [
             Field::make('::normal-field-1::'),
@@ -195,7 +195,7 @@ class FailingStep extends WizardStep
         return false;
     }
 
-    protected function fields(): array
+    public function fields(): array
     {
         return [
             Field::make('::normal-field-1::')
@@ -217,7 +217,7 @@ class StepWithDependentField extends WizardStep
         return $this->data('::dependent-field-1::') !== null;
     }
 
-    protected function fields(): array
+    public function fields(): array
     {
         return [
             Field::make('::dependent-field-1::')
@@ -233,7 +233,7 @@ class AnotherStepWithDependentField extends WizardStep
         return $this->data('::dependent-field-2::') !== null;
     }
 
-    protected function fields(): array
+    public function fields(): array
     {
         return [
             Field::make('::dependent-field-2::')

--- a/tests/WizardTest.php
+++ b/tests/WizardTest.php
@@ -778,7 +778,7 @@ class TestStep extends WizardStep
     public string $title = '::step-1-name::';
     public string $slug = 'step-name';
 
-    protected function fields(): array
+    public function fields(): array
     {
         return [
             Field::make('first_name')

--- a/tests/__snapshots__/files/WizardStepMakeCommandTest__it_prefills_the_steps_slug__1.php
+++ b/tests/__snapshots__/files/WizardStepMakeCommandTest__it_prefills_the_steps_slug__1.php
@@ -26,7 +26,7 @@ class Step1 extends WizardStep
         return parent::viewData($request);
     }
 
-    protected function fields(): array
+    public function fields(): array
     {
         return [
             // Field::make('username')

--- a/tests/__snapshots__/files/WizardStepMakeCommandTest__it_prefills_the_steps_title__1.php
+++ b/tests/__snapshots__/files/WizardStepMakeCommandTest__it_prefills_the_steps_title__1.php
@@ -26,7 +26,7 @@ class Step1 extends WizardStep
         return parent::viewData($request);
     }
 
-    protected function fields(): array
+    public function fields(): array
     {
         return [
             // Field::make('username')


### PR DESCRIPTION
As I wrote in the Issue here: https://github.com/laravel-arcanist/arcanist/issues/9#issuecomment-889270276

We need this change to have access to the fields list in the JsonRenderer which we need to build an Arcanist API for a SPA