### PR TITLE
Add onAfterDelete hook

### DIFF
--- a/src/AbstractWizard.php
+++ b/src/AbstractWizard.php
@@ -233,7 +233,7 @@ abstract class AbstractWizard
 
         $this->wizardRepository->deleteWizard($this);
 
-        return redirect()->to($this->redirectTo());
+        return $this->onAfterDelete();
     }
 
     /**
@@ -305,6 +305,14 @@ abstract class AbstractWizard
     protected function beforeDelete(Request $request): void
     {
         //
+    }
+
+    /**
+     * Gets called after the wizard was deleted.
+     */
+    protected function onAfterDelete(): Response | Responsable | Renderable
+    {
+        return redirect()->to($this->redirectTo());
     }
 
     /**


### PR DESCRIPTION
As discussed in [Issue #19](https://github.com/laravel-arcanist/arcanist/issues/19#issuecomment-892903974) I've added an `onAfterDelete()` hook to the `AbstractWizard`. This allows overwriting the hardcoded `RedirectResponse` similar to the `onAfterComplete()` hook.