### PR TITLE
Change visibility to protected

### DIFF
--- a/src/AbstractWizard.php
+++ b/src/AbstractWizard.php
@@ -78,7 +78,7 @@ abstract class AbstractWizard
 
     public function __construct(
         private WizardRepository $wizardRepository,
-        private ResponseRenderer $responseRenderer,
+        protected ResponseRenderer $responseRenderer,
         private WizardActionResolver $actionResolver
     ) {
         $this->redirectTo = config('arcanist.redirect_url', '/home');

--- a/src/WizardStep.php
+++ b/src/WizardStep.php
@@ -135,7 +135,7 @@ abstract class WizardStep
     /**
      * The validation rules for submitting the step's form.
      */
-    private function rules(): array
+    protected function rules(): array
     {
         return collect($this->fields())
             ->mapWithKeys(fn (Field $field) => [$field->name => $field->rules])


### PR DESCRIPTION
There are some attributes/methods in the `AbstractWizard` and `WizardStep` classes which we need to access in child-classes.

I've changed their visibility to `protected`.