### PR TITLE
fix WizardStep class property title does not return the value of it's `title` method

### DIFF
--- a/src/WizardStep.php
+++ b/src/WizardStep.php
@@ -32,6 +32,7 @@ abstract class WizardStep
         // implement than I currently want to invest.
         $this->wizard = $wizard;
         $this->index = $index;
+        $this->title = $this->title();
 
         return $this;
     }


### PR DESCRIPTION
Currently a WizardSteps title property does not respect the return value of `$this->title()`. For Steps with dynamic titles this should be fixed.