### PR TITLE
Add $request to Action execute() method

### DIFF
--- a/src/AbstractWizard.php
+++ b/src/AbstractWizard.php
@@ -218,7 +218,7 @@ abstract class AbstractWizard
         );
 
         return $this->isLastStep()
-            ? $this->processLastStep($step)
+            ? $this->processLastStep($request, $step)
             : $this->responseRenderer->redirect(
                 $this->nextStep(),
                 $this
@@ -397,7 +397,7 @@ abstract class AbstractWizard
         $this->wizardRepository->saveData($this, $data);
     }
 
-    private function processLastStep(WizardStep $step): Response | Responsable | Renderable
+    private function processLastStep(Request $request, WizardStep $step): Response | Responsable | Renderable
     {
         $this->load($this->id);
 
@@ -405,7 +405,7 @@ abstract class AbstractWizard
 
         $result = $this->actionResolver
             ->resolveAction($this->onCompleteAction)
-            ->execute($this->transformWizardData());
+            ->execute($request, $this->transformWizardData());
 
         if (!$result->successful()) {
             return $this->responseRenderer->redirectWithError(

--- a/src/Action/WizardAction.php
+++ b/src/Action/WizardAction.php
@@ -2,9 +2,11 @@
 
 namespace Arcanist\Action;
 
+use Illuminate\Http\Request;
+
 abstract class WizardAction
 {
-    abstract public function execute($payload): ActionResult;
+    abstract public function execute(Request $request, $payload): ActionResult;
 
     protected function success(array $payload = []): ActionResult
     {


### PR DESCRIPTION
It's common to still need access to things like $request->user() in the execute() method of an action.

There is a request() helper but I thought this make things nicer