### PR TITLE
add currentStepIndex to summary

### DIFF
--- a/src/AbstractWizard.php
+++ b/src/AbstractWizard.php
@@ -266,6 +266,7 @@ abstract class AbstractWizard
 
         return [
             'id' => $this->id,
+            'currentStepIndex' => $this->currentStep,
             'slug' => static::$slug,
             'title' => $this->title(),
             'steps' => collect($this->steps)->map(fn (WizardStep $step) => [

--- a/tests/WizardTest.php
+++ b/tests/WizardTest.php
@@ -242,6 +242,17 @@ class WizardTest extends WizardTestCase
     }
 
     /** @test */
+    public function it_returns_the_wizards_current_step_index_in_the_summary(): void
+    {
+        $wizard = $this->createWizard(TestWizard::class);
+        $wizard->show(new Request(), '1', 'step-with-view-data');
+
+        $summary = $wizard->summary();
+
+        self::assertEquals(1, $summary['currentStepIndex']);
+    }
+
+    /** @test */
     public function it_returns_the_slug_of_each_step_in_the_summary(): void
     {
         $wizard = $this->createWizard(TestWizard::class);


### PR DESCRIPTION
It can be very helpful to easily get the currentStepIndex from the $wizard variable in our blade view. where we can do things like

```blade
{{-- go previous step --}}
href="{{ route("wizard.{$wizard['slug']}::{$wizard['steps'][$wizard['currentStepIndex'] - 1]['slug']}.show") }}" 
```

I named it currentStepIndex instead of currentStep because it is 0 based. Also I think if you decide to add currentStep in the future (starting from 1), it will be less confusing