### PR TITLE
Customize messages and filename

### DIFF
--- a/src/WizardStep.php
+++ b/src/WizardStep.php
@@ -88,7 +88,7 @@ abstract class WizardStep
      */
     public function process(Request $request): StepResult
     {
-        $data = $this->validate($request, $this->rules());
+        $data = $this->validate($request, $this->rules(), $this->messages(), $this->customAttributes());
 
         return collect($this->fields())
             ->mapWithKeys(fn (Field $field) => [
@@ -179,5 +179,23 @@ abstract class WizardStep
         return collect($this->fields())
             ->mapWithKeys(fn (Field $field) => [$field->name => $field->rules])
             ->all();
+    }
+
+    /**
+     * The custom validation messages
+     *
+     * @return array<string, string>
+     */
+    protected function messages(): array {
+        return [];
+    }
+
+    /**
+     * The custom validation messages
+     *
+     * @return array<string, string>
+     */
+    protected function customAttributes(): array {
+        return [];
     }
 }

--- a/src/WizardStep.php
+++ b/src/WizardStep.php
@@ -191,7 +191,7 @@ abstract class WizardStep
     }
 
     /**
-     * The custom validation messages
+     * The custom attributes label
      *
      * @return array<string, string>
      */


### PR DESCRIPTION
Add two methods in WizardSteps:
- the first one allow to define specific error messages 
- the second one allow to customize the name of the field 

The method results are both used as common arguments validation