### PR TITLE
Fix firstIncompleteStep when all step are done

### DIFF
--- a/src/AbstractWizard.php
+++ b/src/AbstractWizard.php
@@ -509,7 +509,7 @@ abstract class AbstractWizard
 
     private function firstIncompleteStep(): WizardStep
     {
-        return collect($this->availableSteps())->first(fn (WizardStep $step) => !$step->isComplete());
+        return collect($this->availableSteps())->first(fn (WizardStep $step) => !$step->isComplete()) ?? $this->steps[count($this->steps) - 1];
     }
 
     /**


### PR DESCRIPTION
I don't know how they do but sometimes my users end the workflow but the action seems to be not called.
I get an issue `Arcanist\AbstractWizard::firstIncompleteStep(): Return value must be of type Arcanist\WizardStep, null returned`

I suppose `availableSteps()` returns an empty collection and the `first` method returns null.
So I use the last step as default value.